### PR TITLE
No exception on dispose

### DIFF
--- a/Modbus/Device/ModbusTcpSlave.cs
+++ b/Modbus/Device/ModbusTcpSlave.cs
@@ -113,8 +113,12 @@ namespace Modbus.Device
             {
                 // use Socket async API for compact framework compat
                 Socket socket = null;
-                lock (_serverLock)
-                    socket = Server.Server.EndAccept(ar);
+				lock (_serverLock)
+				{
+					if (_server == null) // Checks for disposal to an otherwise unnecessary exception (which is slow and hinders debugging).
+						return;
+					socket = Server.Server.EndAccept(ar);
+				}
 
                 TcpClient client = new TcpClient {Client = socket};
                 var masterConnection = new ModbusMasterTcpConnection(client, slave);

--- a/Modbus/Device/ModbusTcpSlave.cs
+++ b/Modbus/Device/ModbusTcpSlave.cs
@@ -113,12 +113,12 @@ namespace Modbus.Device
             {
                 // use Socket async API for compact framework compat
                 Socket socket = null;
-				lock (_serverLock)
-				{
-					if (_server == null) // Checks for disposal to an otherwise unnecessary exception (which is slow and hinders debugging).
-						return;
-					socket = Server.Server.EndAccept(ar);
-				}
+                lock (_serverLock)
+                {
+                    if (_server == null) // Checks for disposal to an otherwise unnecessary exception (which is slow and hinders debugging).
+                        return;
+                    socket = Server.Server.EndAccept(ar);
+                }
 
                 TcpClient client = new TcpClient {Client = socket};
                 var masterConnection = new ModbusMasterTcpConnection(client, slave);


### PR DESCRIPTION
Prevents an exception from being thrown when the slave is stopped. This improves performance and avoids a spurious interruption when debugging with break-on-exception-thrown enabled.