### PR TITLE
Fixes slave illegal data address crash

### DIFF
--- a/Modbus.UnitTests/Data/DataStoreFixture.cs
+++ b/Modbus.UnitTests/Data/DataStoreFixture.cs
@@ -19,14 +19,14 @@ namespace Modbus.UnitTests.Data
             Assert.AreEqual(new ushort[] {1, 2, 3}, result.ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Test, ExpectedException(typeof (InvalidModbusRequestException))]
         public void ReadDataStartAddressTooLarge()
         {
             DataStore.ReadData<DiscreteCollection, bool>(new DataStore(), new ModbusDataCollection<bool>(), 3, 2,
                 new object());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Test, ExpectedException(typeof (InvalidModbusRequestException))]
         public void ReadDataCountTooLarge()
         {
             DataStore.ReadData<DiscreteCollection, bool>(new DataStore(),
@@ -59,7 +59,7 @@ namespace Modbus.UnitTests.Data
             Assert.AreEqual(new bool[] {false, true, true, true, true, false, false, true}, destination.ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
         public void WriteDataTooLarge()
         {
             ModbusDataCollection<bool> slaveCol = new ModbusDataCollection<bool>(true);
@@ -74,7 +74,7 @@ namespace Modbus.UnitTests.Data
                 new ModbusDataCollection<bool>(true, true), 0, new object());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
         public void WriteDataStartAddressTooLarge()
         {
             DataStore.WriteData(new DataStore(), new DiscreteCollection(true), new ModbusDataCollection<bool>(true), 2,
@@ -229,7 +229,7 @@ namespace Modbus.UnitTests.Data
             Assert.AreEqual(new int[] {1, 2, 3, 4, 5, 6}, destination.ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
         public void UpdateItemsTooLarge()
         {
             List<int> newItems = new List<int>(new int[] {1, 2, 3, 7, 8, 9});
@@ -237,7 +237,7 @@ namespace Modbus.UnitTests.Data
             DataStore.Update<int>(newItems, destination, 3);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
         public void UpdateNegativeIndex()
         {
             List<int> newItems = new List<int>(new int[] {1, 2, 3, 7, 8, 9});

--- a/Modbus/Data/DataStore.cs
+++ b/Modbus/Data/DataStore.cs
@@ -75,12 +75,8 @@ namespace Modbus.Data
         {
             int startIndex = startAddress + 1;
 
-            if (startIndex < 0 || startIndex >= dataSource.Count)
-                throw new ArgumentOutOfRangeException(
-                    "Start address was out of range. Must be non-negative and <= the size of the collection.");
-
-            if (dataSource.Count < startIndex + count)
-                throw new ArgumentOutOfRangeException("Read is outside valid range.");
+            if (startIndex < 0 || dataSource.Count < startIndex + count)
+                throw new InvalidModbusRequestException(Modbus.IllegalDataAddress);
 
             U[] dataToRetrieve;
             lock (syncRoot)
@@ -105,12 +101,8 @@ namespace Modbus.Data
         {
             int startIndex = startAddress + 1;
 
-            if (startIndex < 0 || startIndex >= destination.Count)
-                throw new ArgumentOutOfRangeException(
-                    "Start address was out of range. Must be non-negative and <= the size of the collection.");
-
-            if (destination.Count < startIndex + items.Count())
-                throw new ArgumentOutOfRangeException("Items collection is too large to write at specified start index.");
+            if (startIndex < 0 || destination.Count < startIndex + items.Count())
+                throw new InvalidModbusRequestException(Modbus.IllegalDataAddress);
 
             lock (syncRoot)
                 Update(items, destination, startIndex);
@@ -125,8 +117,7 @@ namespace Modbus.Data
         internal static void Update<T>(IEnumerable<T> items, IList<T> destination, int startIndex)
         {
             if (startIndex < 0 || destination.Count < startIndex + items.Count())
-                throw new ArgumentOutOfRangeException(
-                    "Index was out of range. Must be non-negative and less than the size of the collection.");
+                throw new InvalidModbusRequestException(Modbus.IllegalDataAddress);
 
             items.ForEachWithIndex((item, index) => destination[index + startIndex] = item);
         }

--- a/Modbus/Modbus.cs
+++ b/Modbus/Modbus.cs
@@ -26,6 +26,7 @@ namespace Modbus
 
         // modbus slave exception codes
         public const byte IllegalFunction = 1;
+        public const byte IllegalDataAddress = 2;
         public const byte Acknowledge = 5;
         public const byte SlaveDeviceBusy = 6;
 


### PR DESCRIPTION
Fixes an unhandled exception when a Modbus slave receives a request with an invalid data address.