### PR TITLE
Proper way to dispose ModbusTcpSlave

### DIFF
--- a/Modbus/Device/ModbusMasterTcpConnection.cs
+++ b/Modbus/Device/ModbusMasterTcpConnection.cs
@@ -140,10 +140,22 @@ namespace Modbus.Device
             catch (Exception ex)
             {
                 Debug.WriteLine("Exception processing request: [{0}] {1}", ex.GetType().Name, ex.Message);
-                if (!(ex is IOException || ex is FormatException))
-                    throw; // This will typically result in the exception being unhandled, which will terminate the thread pool thread and thereby the process, depending on the process's configuration. Such a crash would cause all connections to be dropped, even if the slave were restarted.
-                // Otherwise, the request is discarded and the slave awaits the next message. If the master is unable to synchronize the frame, it can drop the connection.
+
+                // This will typically result in the exception being unhandled, which will terminate the thread pool thread and
+                // thereby the process, depending on the process's configuration. Such a crash would cause all connections to be
+                // dropped, even if the slave were restarted.
+                // Otherwise, the request is discarded and the slave awaits the next message. If the master is unable to synchronize
+                //the frame, it can drop the connection.
+                if (!(ex is IOException || ex is FormatException || ex is ObjectDisposedException))
+                    throw;
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _stream.Close();
+            base.Dispose(disposing);
         }
     }
 }

--- a/Modbus/Device/ModbusTcpSlave.cs
+++ b/Modbus/Device/ModbusTcpSlave.cs
@@ -92,20 +92,20 @@ namespace Modbus.Device
             }
         }
 
-        internal void RemoveMaster(string endPoint)
+        private void OnMasterConnectionClosedHandler(object sender, TcpConnectionEventArgs e)
         {
             ModbusMasterTcpConnection connection;
-            if (!_masters.TryRemove(endPoint, out connection))
+            if (!_masters.TryRemove(e.EndPoint, out connection))
             {
                 var msg = string.Format(
                     CultureInfo.InvariantCulture,
                     "EndPoint {0} cannot be removed, it does not exist.",
-                    endPoint);
+                    e.EndPoint);
 
                 throw new ArgumentException(msg);
             }
 
-            Debug.WriteLine("Removed Master {0}", endPoint);
+            Debug.WriteLine("Removed Master {0}", e.EndPoint);
         }
 
         internal void AcceptCompleted(IAsyncResult ar)
@@ -127,8 +127,7 @@ namespace Modbus.Device
 
                     TcpClient client = new TcpClient {Client = socket};
                     var masterConnection = new ModbusMasterTcpConnection(client, slave);
-                    masterConnection.ModbusMasterTcpConnectionClosed +=
-                        (sender, eventArgs) => RemoveMaster(eventArgs.EndPoint);
+                    masterConnection.ModbusMasterTcpConnectionClosed += OnMasterConnectionClosedHandler;
 
                     _masters.TryAdd(client.Client.RemoteEndPoint.ToString(), masterConnection);
 

--- a/Modbus/Device/ModbusTcpSlave.cs
+++ b/Modbus/Device/ModbusTcpSlave.cs
@@ -171,6 +171,16 @@ namespace Modbus.Device
                         {
                             _server.Stop();
                             _server = null;
+
+                            foreach (var key in _masters.Keys)
+                            {
+                                ModbusMasterTcpConnection connection;
+                                if (_masters.TryRemove(key, out connection))
+                                {
+                                    connection.ModbusMasterTcpConnectionClosed -= OnMasterConnectionClosedHandler;
+                                    connection.Dispose();
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The problem is that when `ModbusTcpSlave` disposed, his `ModbusMasterTcpConnection`s are still opened.