### PR TITLE
Restored original copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Documentation is available in chm format (NModbus.chm)
 
 The MIT License (MIT)
 =======
-Copyright (c) 2014 Maxwe11
+Copyright (c) 2006 Scott Alexander, 2014 Maxwe11
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The original MIT license requires the original copyright notice be retained. [More info](http://stackoverflow.com/q/13936870/145173)